### PR TITLE
Added Throwable::Error so LibXML errors can be caught

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,3 +11,4 @@ requires 'XML::Compile::Cache', '0';
 requires 'XML::LibXML', '0';
 requires 'File::Slurp::Tiny', '0';
 requires 'File::Spec' , '0';
+requires 'Try::Tiny', '0';

--- a/lib/Lido/XML.pm
+++ b/lib/Lido/XML.pm
@@ -4,9 +4,12 @@ our $VERSION = '0.05';
 
 use Moo;
 use Lido::XML::LIDO_1_0;
+use Lido::XML::Error;
 use XML::Compile;
 use XML::Compile::Schema;
 use XML::Compile::Util 'pack_type';
+use Try::Tiny;
+
 
 has 'namespace' => (is => 'ro' , default => sub {'http://www.lido-schema.org'});
 has 'root'      => (is => 'ro' , default => sub {'lido'});
@@ -56,7 +59,12 @@ sub parse {
 sub to_xml {
 	my ($self,$data) = @_;
 	my $doc    = XML::LibXML::Document->new('1.0', 'UTF-8');
-	my $xml    = $self->writer->($doc, $data);
+	my $xml;
+	try {
+		$xml    = $self->writer->($doc, $data);
+	} catch {
+		Lido::XML::Error->throw(sprintf('%s', $_));
+	};
 	$doc->setDocumentElement($xml);
 	$doc->toString(1);
 }

--- a/lib/Lido/XML/Error.pm
+++ b/lib/Lido/XML/Error.pm
@@ -1,0 +1,8 @@
+package Lido::XML::Error;
+
+use Moo;
+extends 'Throwable::Error';
+
+
+
+1;


### PR DESCRIPTION
Adding Throwable::Error so you can use a try-catch block to catch any LibXML errors.